### PR TITLE
Fixes feature

### DIFF
--- a/features/bootstrap/OpenMarket/APIBundle/Features/User.feature
+++ b/features/bootstrap/OpenMarket/APIBundle/Features/User.feature
@@ -4,6 +4,6 @@ Feature: Market users
   I need to be able to get users resource API
 
 Scenario: Getting a single user by id
-  Given: I prepare a GET request on "/api/users"
-  When: I send the request
-  Then: I should receive a 200 response
+  Given I prepare a GET request on "/api/users"
+  When I send the request
+  Then I should receive a 200 response


### PR DESCRIPTION
The `:` were causing behat not to find the instructions